### PR TITLE
Kp/inserting flexible height content between week rows

### DIFF
--- a/Example/HorizonCalendarExample/HorizonCalendarExample.xcodeproj/project.pbxproj
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		AA79A7D52D74346200C07DD0 /* DayRangeSelectionHelperExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA79A7D42D74346200C07DD0 /* DayRangeSelectionHelperExtension.swift */; };
 		AA79A7E02D74E1F400C07DD0 /* SwiftUIWeekViewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA79A7DF2D74E1F400C07DD0 /* SwiftUIWeekViewViewController.swift */; };
 		AA79A83E2D750BCC00C07DD0 /* SwiftUIFlexWeekViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA79A83D2D750BCC00C07DD0 /* SwiftUIFlexWeekViewController.swift */; };
+		AA79A88A2D751C0600C07DD0 /* SelectedDayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA79A8892D751C0600C07DD0 /* SelectedDayView.swift */; };
 		FD55C5D7298B138A00A9B5D6 /* SwiftUIScreenDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD55C5D6298B138A00A9B5D6 /* SwiftUIScreenDemoViewController.swift */; };
 		FDA0FB3528F5EFD90066DEFA /* SwiftUIDayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA0FB3428F5EFD90066DEFA /* SwiftUIDayView.swift */; };
 		FDA0FB3728F5EFF60066DEFA /* SwiftUIItemModelsDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA0FB3628F5EFF60066DEFA /* SwiftUIItemModelsDemoViewController.swift */; };
@@ -71,6 +72,7 @@
 		AA79A7D42D74346200C07DD0 /* DayRangeSelectionHelperExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayRangeSelectionHelperExtension.swift; sourceTree = "<group>"; };
 		AA79A7DF2D74E1F400C07DD0 /* SwiftUIWeekViewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIWeekViewViewController.swift; sourceTree = "<group>"; };
 		AA79A83D2D750BCC00C07DD0 /* SwiftUIFlexWeekViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIFlexWeekViewController.swift; sourceTree = "<group>"; };
+		AA79A8892D751C0600C07DD0 /* SelectedDayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedDayView.swift; sourceTree = "<group>"; };
 		FD55C5D6298B138A00A9B5D6 /* SwiftUIScreenDemoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIScreenDemoViewController.swift; sourceTree = "<group>"; };
 		FDA0FB3428F5EFD90066DEFA /* SwiftUIDayView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftUIDayView.swift; sourceTree = "<group>"; };
 		FDA0FB3628F5EFF60066DEFA /* SwiftUIItemModelsDemoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftUIItemModelsDemoViewController.swift; sourceTree = "<group>"; };
@@ -138,6 +140,7 @@
 				AA79A7D42D74346200C07DD0 /* DayRangeSelectionHelperExtension.swift */,
 				FDA0FB3428F5EFD90066DEFA /* SwiftUIDayView.swift */,
 				939853512498992E0022A3A1 /* TooltipView.swift */,
+				AA79A8892D751C0600C07DD0 /* SelectedDayView.swift */,
 				939E69732484CD9000A8BCC7 /* Assets.xcassets */,
 				939E69752484CD9000A8BCC7 /* LaunchScreen.storyboard */,
 				939E69782484CD9000A8BCC7 /* Info.plist */,
@@ -234,6 +237,7 @@
 				9381769C249B74BB00E18FA3 /* DemoPickerViewController.swift in Sources */,
 				939853522498992E0022A3A1 /* TooltipView.swift in Sources */,
 				AA79A7D52D74346200C07DD0 /* DayRangeSelectionHelperExtension.swift in Sources */,
+				AA79A88A2D751C0600C07DD0 /* SelectedDayView.swift in Sources */,
 				AA79A83E2D750BCC00C07DD0 /* SwiftUIFlexWeekViewController.swift in Sources */,
 				938176A7249B85CE00E18FA3 /* DemoViewController.swift in Sources */,
 				9381769F249B79DC00E18FA3 /* ScrollToDayWithAnimationDemoViewController.swift in Sources */,

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIFlexWeekViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIFlexWeekViewController.swift
@@ -128,16 +128,13 @@ struct SwiftUIFlexWeekDemo: View {
             }
 
             .onDaySelection { day in
-                DayRangeSelectionHelper.updateDayRange(
-                    afterTapSelectionOf: day,
-                    existingDayRange: &selectedDayRange
-                )
+                selectedDayRange = day...day
             }
             .onAppear {
                 calendarViewProxy.scrollToDay(
                     containing: calendar.date(from: DateComponents(year: 2025, month: 04, day: 01))!,
                     scrollPosition: .centered,
-                    animated: false
+                    animated: true
                 )
             }
             .frame(maxWidth: 375, maxHeight: .infinity)

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIFlexWeekViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIFlexWeekViewController.swift
@@ -147,7 +147,13 @@ struct SwiftUIFlexWeekDemo: View {
                     content: SelectedDayView.Content(
                         frameOfTooltippedItem: frame,
                         text: dayDateFormatter.string(from: selectedDate),
-                        notes: "None")
+                        notes: "None", scrollToSelectedDate: {
+                            calendarViewProxy.scrollToDay(
+                                containing: selectedDate,
+                                scrollPosition: .firstFullyVisiblePosition(padding: 150),
+                                animated: false
+                            )
+                        })
                     )
             }
             

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIFlexWeekViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIFlexWeekViewController.swift
@@ -48,7 +48,7 @@ final class SwiftUIFlexWeekViewController: UIViewController, DemoViewController 
             hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
-            hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
 
         hostingController.didMove(toParent: self)
@@ -79,9 +79,9 @@ struct SwiftUIFlexWeekDemo: View {
     }
 
     // MARK: Internal
-    
+
     @State var overlaidItemLocations: Set<OverlaidItemLocation> = []
-    @State var selectedDate: Date = Date()
+    @State var selectedDate: Date = .init()
 
     var body: some View {
         ZStack {
@@ -94,7 +94,7 @@ struct SwiftUIFlexWeekDemo: View {
             )
 
             .interMonthSpacing(24)
-            .verticalDayMargin(self.lineSpacing)
+            .verticalDayMargin(lineSpacing)
             .horizontalDayMargin(10)
             .monthHeaders { month in
                 let monthHeaderText = monthDateFormatter.string(from: calendar.date(from: month.components)!)
@@ -129,19 +129,18 @@ struct SwiftUIFlexWeekDemo: View {
             }
 
             .onDaySelection { day in
-                selectedDayRange = day...day
+                selectedDayRange = day ... day
                 selectedDate = calendar.date(from: day.components)!
                 overlaidItemLocations = [.day(containingDate: selectedDate)]
                 lineSpacing = 100
-                
             }
-            
+
             .overlayItemProvider(for: overlaidItemLocations) { overlayLayoutContext in
-                
+
                 let screenWidth = UIScreen.main.bounds.width
                 let yValue = overlayLayoutContext.overlaidItemFrame.origin.y
                 let frame = CGRect(x: 0, y: yValue, width: screenWidth, height: 100)
-                
+
                 return SelectedDayView.calendarItemModel(
                     invariantViewProperties: .init(),
                     content: SelectedDayView.Content(
@@ -153,10 +152,11 @@ struct SwiftUIFlexWeekDemo: View {
                                 scrollPosition: .lastFullyVisiblePosition(padding: 50),
                                 animated: false
                             )
-                        })
+                        }
                     )
+                )
             }
-            
+
             .onAppear {
                 calendarViewProxy.scrollToDay(
                     containing: calendar.date(from: DateComponents(year: 2025, month: 04, day: 01))!,
@@ -194,7 +194,7 @@ struct SwiftUIFlexWeekDemo: View {
 
     @State private var selectedDayRange: DayComponentsRange?
     @State private var selectedDayRangeAtStartOfDrag: DayComponentsRange?
-    
+
     @State private var showErrorMessage: Bool = false
     @State private var lineSpacing: CGFloat = 28
 

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIFlexWeekViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIFlexWeekViewController.swift
@@ -150,7 +150,7 @@ struct SwiftUIFlexWeekDemo: View {
                         notes: "None", scrollToSelectedDate: {
                             calendarViewProxy.scrollToDay(
                                 containing: selectedDate,
-                                scrollPosition: .firstFullyVisiblePosition(padding: 150),
+                                scrollPosition: .lastFullyVisiblePosition(padding: 50),
                                 animated: false
                             )
                         })

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIFlexWeekViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIFlexWeekViewController.swift
@@ -133,7 +133,7 @@ struct SwiftUIFlexWeekDemo: View {
             .onAppear {
                 calendarViewProxy.scrollToDay(
                     containing: calendar.date(from: DateComponents(year: 2025, month: 04, day: 01))!,
-                    scrollPosition: .centered,
+                    scrollPosition: .firstFullyVisiblePosition(padding: 50),
                     animated: true
                 )
             }

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIFlexWeekViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIFlexWeekViewController.swift
@@ -81,6 +81,7 @@ struct SwiftUIFlexWeekDemo: View {
     // MARK: Internal
     
     @State var overlaidItemLocations: Set<OverlaidItemLocation> = []
+    @State var selectedDate: Date = Date()
 
     var body: some View {
         ZStack {
@@ -129,17 +130,25 @@ struct SwiftUIFlexWeekDemo: View {
 
             .onDaySelection { day in
                 selectedDayRange = day...day
-                overlaidItemLocations = [.day(containingDate: calendar.date(from: day.components)!)]
+                selectedDate = calendar.date(from: day.components)!
+                overlaidItemLocations = [.day(containingDate: selectedDate)]
                 lineSpacing = 100
+                
             }
             
             .overlayItemProvider(for: overlaidItemLocations) { overlayLayoutContext in
                 
-              return TooltipView.calendarItemModel(
-                invariantViewProperties: .init(),
-                content: .init(
-                    frameOfTooltippedItem: overlayLayoutContext.overlaidItemFrame,
-                    text: "Selected Day"))
+                let screenWidth = UIScreen.main.bounds.width
+                let yValue = overlayLayoutContext.overlaidItemFrame.origin.y
+                let frame = CGRect(x: 0, y: yValue, width: screenWidth, height: 100)
+                
+                return SelectedDayView.calendarItemModel(
+                    invariantViewProperties: .init(),
+                    content: SelectedDayView.Content(
+                        frameOfTooltippedItem: frame,
+                        text: dayDateFormatter.string(from: selectedDate),
+                        notes: "None")
+                    )
             }
             
             .onAppear {

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIFlexWeekViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIFlexWeekViewController.swift
@@ -79,8 +79,8 @@ struct SwiftUIFlexWeekDemo: View {
     }
 
     // MARK: Internal
-
-    @State private var showErrorMessage: Bool = false
+    
+    @State var overlaidItemLocations: Set<OverlaidItemLocation> = []
 
     var body: some View {
         ZStack {
@@ -92,8 +92,8 @@ struct SwiftUIFlexWeekDemo: View {
                 proxy: calendarViewProxy
             )
 
-            .interMonthSpacing(28)
-            .verticalDayMargin(28)
+            .interMonthSpacing(24)
+            .verticalDayMargin(self.lineSpacing)
             .horizontalDayMargin(10)
             .monthHeaders { month in
                 let monthHeaderText = monthDateFormatter.string(from: calendar.date(from: month.components)!)
@@ -129,7 +129,19 @@ struct SwiftUIFlexWeekDemo: View {
 
             .onDaySelection { day in
                 selectedDayRange = day...day
+                overlaidItemLocations = [.day(containingDate: calendar.date(from: day.components)!)]
+                lineSpacing = 100
             }
+            
+            .overlayItemProvider(for: overlaidItemLocations) { overlayLayoutContext in
+                
+              return TooltipView.calendarItemModel(
+                invariantViewProperties: .init(),
+                content: .init(
+                    frameOfTooltippedItem: overlayLayoutContext.overlaidItemFrame,
+                    text: "Selected Day"))
+            }
+            
             .onAppear {
                 calendarViewProxy.scrollToDay(
                     containing: calendar.date(from: DateComponents(year: 2025, month: 04, day: 01))!,
@@ -167,6 +179,9 @@ struct SwiftUIFlexWeekDemo: View {
 
     @State private var selectedDayRange: DayComponentsRange?
     @State private var selectedDayRangeAtStartOfDrag: DayComponentsRange?
+    
+    @State private var showErrorMessage: Bool = false
+    @State private var lineSpacing: CGFloat = 28
 
     private var selectedDateRanges: Set<ClosedRange<Date>> {
         guard let selectedDayRange else { return [] }

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/SelectedDayView.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/SelectedDayView.swift
@@ -1,0 +1,152 @@
+// Created by Bryan Keller on 6/15/20.
+// Copyright © 2020 Airbnb Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import HorizonCalendar
+import SwiftUICore
+import UIKit
+
+// MARK: - TooltipView
+
+final class SelectedDayView: UIView {
+    // MARK: Lifecycle
+
+    fileprivate init(invariantViewProperties: InvariantViewProperties) {
+        backgroundView = UIView()
+        backgroundView.backgroundColor = invariantViewProperties.backgroundColor
+        backgroundView.layer.borderColor = invariantViewProperties.borderColor.cgColor
+        backgroundView.layer.borderWidth = 1
+        backgroundView.layer.cornerRadius = 6
+
+        dateLabel = UILabel()
+        dateLabel.font = invariantViewProperties.font
+        dateLabel.textAlignment = invariantViewProperties.textAlignment
+        dateLabel.lineBreakMode = .byTruncatingTail
+        dateLabel.textColor = invariantViewProperties.textColor
+        
+        notes = UITextField()
+        notes.font = invariantViewProperties.font
+        notes.textColor = invariantViewProperties.textColor
+        notes.textAlignment = invariantViewProperties.textAlignment
+        notes.borderStyle = .roundedRect
+        notes.placeholder = "Enter your notes here..."
+        notes.layer.borderColor = invariantViewProperties.borderColor.cgColor
+        notes.layer.borderWidth = 1
+        notes.layer.cornerRadius = 6
+        notes.backgroundColor = invariantViewProperties.backgroundColor
+        
+
+        super.init(frame: .zero)
+
+        isUserInteractionEnabled = false
+        addSubview(backgroundView)
+        addSubview(dateLabel)
+        addSubview(notes)
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: Internal
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        guard let frameOfTooltippedItem else { return }
+
+        dateLabel.sizeToFit()
+        let labelSize = CGSize(
+            width: max(dateLabel.bounds.size.width, bounds.width),
+            height: dateLabel.bounds.size.height
+        )
+
+        let backgroundSize = CGSize(width: labelSize.width, height: labelSize.height)
+
+        let proposedFrame = CGRect(
+            x: frameOfTooltippedItem.minX,
+            y: frameOfTooltippedItem.minY - backgroundSize.height,
+            width: frameOfTooltippedItem.width,
+            height: frameOfTooltippedItem.height
+        )
+
+        let frame: CGRect = if proposedFrame.maxX > bounds.width {
+            proposedFrame.applying(.init(translationX: bounds.width - proposedFrame.maxX, y: 0))
+        } else if proposedFrame.minX < 0 {
+            proposedFrame.applying(.init(translationX: -proposedFrame.minX, y: 0))
+        } else {
+            proposedFrame
+        }
+
+        backgroundView.frame = frame
+        dateLabel.center = backgroundView.center
+    }
+
+    // MARK: Fileprivate
+
+    fileprivate var frameOfTooltippedItem: CGRect? {
+        didSet {
+            guard frameOfTooltippedItem != oldValue else { return }
+            setNeedsLayout()
+        }
+    }
+
+    fileprivate var dateText: String {
+        get { dateLabel.text ?? "" }
+        set { dateLabel.text = newValue }
+    }
+    
+    fileprivate var fieldTextContent: String {
+        get { notes.text ?? "" }
+        set { notes.text = newValue }
+    }
+
+    // MARK: Private
+
+    private let backgroundView: UIView
+    private let dateLabel: UILabel
+    private let notes: UITextField
+}
+
+// MARK: CalendarItemViewRepresentable
+
+extension SelectedDayView: CalendarItemViewRepresentable {
+    struct InvariantViewProperties: Hashable {
+        var backgroundColor = UIColor.white
+        var borderColor = UIColor.black
+        var font = UIFont.systemFont(ofSize: 16)
+        var textAlignment = NSTextAlignment.center
+        var textColor = UIColor.black
+    }
+
+    struct Content: Equatable {
+        let frameOfTooltippedItem: CGRect?
+        let text: String
+        let notes: String?
+    }
+
+    static func makeView(
+        withInvariantViewProperties invariantViewProperties: InvariantViewProperties)
+        -> SelectedDayView
+    {
+        SelectedDayView(invariantViewProperties: invariantViewProperties)
+    }
+
+    static func setContent(_ content: Content, on view: SelectedDayView) {
+        view.frameOfTooltippedItem = content.frameOfTooltippedItem
+        view.dateText = content.text
+        view.fieldTextContent = content.notes ?? ""
+    }
+}

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/SelectedDayView.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/SelectedDayView.swift
@@ -45,7 +45,7 @@ final class SelectedDayView: UIView, UITextFieldDelegate {
         notes.layer.borderColor = invariantViewProperties.borderColor.cgColor
         notes.layer.borderWidth = 1
         notes.layer.cornerRadius = 6
-        notes.backgroundColor = invariantViewProperties.backgroundColor
+        notes.backgroundColor = invariantViewProperties.borderColor.withAlphaComponent(0.1)
 
         super.init(frame: .zero)
 
@@ -94,15 +94,6 @@ final class SelectedDayView: UIView, UITextFieldDelegate {
                              width: dateLabel.frame.width,
                              height: backgroundView.frame.height - dateLabelHeight - buffer * 3
         )
-        notes.backgroundColor = .red
-        
-        dateLabel.backgroundColor = .cyan
-        
-        backgroundView.backgroundColor = .yellow
-        
-        print("notes isUserInteractionEnabled: ", notes.isUserInteractionEnabled)
-        print("bgView isUserInteractionEnabled: ", backgroundView.isUserInteractionEnabled)
-        print("super isUserInteractionEnabled: ", super.isUserInteractionEnabled)
         
         backgroundView.addSubview(dateLabel)
         backgroundView.addSubview(notes)

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/SelectedDayView.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/SelectedDayView.swift
@@ -35,7 +35,7 @@ final class SelectedDayView: UIView, UITextFieldDelegate {
         dateLabel.textAlignment = invariantViewProperties.textAlignment
         dateLabel.lineBreakMode = .byTruncatingTail
         dateLabel.textColor = invariantViewProperties.textColor
-        
+
         notes = UITextField()
         notes.font = invariantViewProperties.font
         notes.textColor = invariantViewProperties.textColor
@@ -45,7 +45,8 @@ final class SelectedDayView: UIView, UITextFieldDelegate {
         notes.layer.borderColor = invariantViewProperties.borderColor.cgColor
         notes.layer.borderWidth = 1
         notes.layer.cornerRadius = 6
-        notes.backgroundColor = invariantViewProperties.borderColor.withAlphaComponent(0.1)
+        notes.backgroundColor = invariantViewProperties.borderColor.withAlphaComponent(0.1
+        )
 
         super.init(frame: .zero)
 
@@ -69,9 +70,9 @@ final class SelectedDayView: UIView, UITextFieldDelegate {
 
         let backgroundSize = CGSize(width: frameOfTooltippedItem.width,
                                     height: frameOfTooltippedItem.height)
-        
+
         let dateLabelHeight: CGFloat = 20
-        
+
         let buffer: CGFloat = 5
 
         let proposedFrame = CGRect(
@@ -82,28 +83,26 @@ final class SelectedDayView: UIView, UITextFieldDelegate {
         )
 
         backgroundView.frame = proposedFrame
-        
+
         dateLabel.frame = CGRect(x: buffer,
                                  y: buffer,
                                  width: backgroundView.frame.width - 10,
-                                 height: dateLabelHeight
-        )
-        
+                                 height: dateLabelHeight)
+
         notes.frame = CGRect(x: 5,
                              y: buffer * 2 + dateLabelHeight,
                              width: dateLabel.frame.width,
-                             height: backgroundView.frame.height - dateLabelHeight - buffer * 3
-        )
-        
+                             height: backgroundView.frame.height - dateLabelHeight - buffer * 3)
+
         backgroundView.addSubview(dateLabel)
         backgroundView.addSubview(notes)
     }
-    
-    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+
+    override func touchesBegan(_: Set<UITouch>, with _: UIEvent?) {
         resignFirstResponder()
     }
-    
-    func textFieldDidBeginEditing(_ textField: UITextField) {
+
+    func textFieldDidBeginEditing(_: UITextField) {
         scrollToSelectedDate?()
     }
 
@@ -111,7 +110,7 @@ final class SelectedDayView: UIView, UITextFieldDelegate {
         textField.resignFirstResponder()
         return true
     }
-    
+
     // MARK: Fileprivate
 
     fileprivate var frameOfTooltippedItem: CGRect? {
@@ -125,7 +124,7 @@ final class SelectedDayView: UIView, UITextFieldDelegate {
         get { dateLabel.text ?? "" }
         set { dateLabel.text = newValue }
     }
-    
+
     fileprivate var fieldTextContent: String {
         get { notes.text ?? "" }
         set { notes.text = newValue }
@@ -152,11 +151,11 @@ extension SelectedDayView: CalendarItemViewRepresentable {
 
     struct Content: Equatable {
         static func == (lhs: SelectedDayView.Content, rhs: SelectedDayView.Content) -> Bool {
-            return lhs.frameOfTooltippedItem == rhs.frameOfTooltippedItem &&
-                   lhs.text == rhs.text &&
-                   lhs.notes == rhs.notes
+            lhs.frameOfTooltippedItem == rhs.frameOfTooltippedItem &&
+                lhs.text == rhs.text &&
+                lhs.notes == rhs.notes
         }
-        
+
         let frameOfTooltippedItem: CGRect?
         let text: String
         let notes: String?

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/TooltipView.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/TooltipView.swift
@@ -115,7 +115,6 @@ extension TooltipView: CalendarItemViewRepresentable {
     struct Content: Equatable {
         let frameOfTooltippedItem: CGRect?
         let text: String
-        let customView: UIView
     }
 
     static func makeView(

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/TooltipView.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/TooltipView.swift
@@ -14,119 +14,119 @@
 // limitations under the License.
 
 import HorizonCalendar
+import SwiftUICore
 import UIKit
 
 // MARK: - TooltipView
 
 final class TooltipView: UIView {
+    // MARK: Lifecycle
 
-  // MARK: Lifecycle
+    fileprivate init(invariantViewProperties: InvariantViewProperties) {
+        backgroundView = UIView()
+        backgroundView.backgroundColor = invariantViewProperties.backgroundColor
+        backgroundView.layer.borderColor = invariantViewProperties.borderColor.cgColor
+        backgroundView.layer.borderWidth = 1
+        backgroundView.layer.cornerRadius = 6
 
-  fileprivate init(invariantViewProperties: InvariantViewProperties) {
-    backgroundView = UIView()
-    backgroundView.backgroundColor = invariantViewProperties.backgroundColor
-    backgroundView.layer.borderColor = invariantViewProperties.borderColor.cgColor
-    backgroundView.layer.borderWidth = 1
-    backgroundView.layer.cornerRadius = 6
+        label = UILabel()
+        label.font = invariantViewProperties.font
+        label.textAlignment = invariantViewProperties.textAlignment
+        label.lineBreakMode = .byTruncatingTail
+        label.textColor = invariantViewProperties.textColor
 
-    label = UILabel()
-    label.font = invariantViewProperties.font
-    label.textAlignment = invariantViewProperties.textAlignment
-    label.lineBreakMode = .byTruncatingTail
-    label.textColor = invariantViewProperties.textColor
+        super.init(frame: .zero)
 
-    super.init(frame: .zero)
-
-    isUserInteractionEnabled = false
-    addSubview(backgroundView)
-    addSubview(label)
-  }
-
-  required init?(coder _: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
-
-  // MARK: Internal
-
-  override func layoutSubviews() {
-    super.layoutSubviews()
-
-    guard let frameOfTooltippedItem else { return }
-
-    label.sizeToFit()
-    let labelSize = CGSize(
-      width: min(label.bounds.size.width, bounds.width),
-      height: label.bounds.size.height)
-
-    let backgroundSize = CGSize(width: labelSize.width + 16, height: labelSize.height + 16)
-
-    let proposedFrame = CGRect(
-      x: frameOfTooltippedItem.midX - (backgroundSize.width / 2),
-      y: frameOfTooltippedItem.minY - backgroundSize.height - 4,
-      width: backgroundSize.width,
-      height: backgroundSize.height)
-
-    let frame: CGRect
-    if proposedFrame.maxX > bounds.width {
-      frame = proposedFrame.applying(.init(translationX: bounds.width - proposedFrame.maxX, y: 0))
-    } else if proposedFrame.minX < 0 {
-      frame = proposedFrame.applying(.init(translationX: -proposedFrame.minX, y: 0))
-    } else {
-      frame = proposedFrame
+        isUserInteractionEnabled = false
+        addSubview(backgroundView)
+        addSubview(label)
     }
 
-    backgroundView.frame = frame
-    label.center = backgroundView.center
-  }
-
-  // MARK: Fileprivate
-
-  fileprivate var frameOfTooltippedItem: CGRect? {
-    didSet {
-      guard frameOfTooltippedItem != oldValue else { return }
-      setNeedsLayout()
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
-  }
 
-  fileprivate var text: String {
-    get { label.text ?? "" }
-    set { label.text = newValue }
-  }
+    // MARK: Internal
 
-  // MARK: Private
+    override func layoutSubviews() {
+        super.layoutSubviews()
 
-  private let backgroundView: UIView
-  private let label: UILabel
+        guard let frameOfTooltippedItem else { return }
 
+        label.sizeToFit()
+        let labelSize = CGSize(
+            width: min(label.bounds.size.width, bounds.width),
+            height: label.bounds.size.height
+        )
+
+        let backgroundSize = CGSize(width: labelSize.width + 16, height: labelSize.height + 16)
+
+        let proposedFrame = CGRect(
+            x: frameOfTooltippedItem.midX - (backgroundSize.width / 2),
+            y: frameOfTooltippedItem.minY - backgroundSize.height - 4,
+            width: backgroundSize.width,
+            height: backgroundSize.height
+        )
+
+        let frame: CGRect = if proposedFrame.maxX > bounds.width {
+            proposedFrame.applying(.init(translationX: bounds.width - proposedFrame.maxX, y: 0))
+        } else if proposedFrame.minX < 0 {
+            proposedFrame.applying(.init(translationX: -proposedFrame.minX, y: 0))
+        } else {
+            proposedFrame
+        }
+
+        backgroundView.frame = frame
+        label.center = backgroundView.center
+    }
+
+    // MARK: Fileprivate
+
+    fileprivate var frameOfTooltippedItem: CGRect? {
+        didSet {
+            guard frameOfTooltippedItem != oldValue else { return }
+            setNeedsLayout()
+        }
+    }
+
+    fileprivate var text: String {
+        get { label.text ?? "" }
+        set { label.text = newValue }
+    }
+
+    // MARK: Private
+
+    private let backgroundView: UIView
+    private let label: UILabel
 }
 
 // MARK: CalendarItemViewRepresentable
 
 extension TooltipView: CalendarItemViewRepresentable {
+    struct InvariantViewProperties: Hashable {
+        var backgroundColor = UIColor.white
+        var borderColor = UIColor.black
+        var font = UIFont.systemFont(ofSize: 16)
+        var textAlignment = NSTextAlignment.center
+        var textColor = UIColor.black
+    }
 
-  struct InvariantViewProperties: Hashable {
-    var backgroundColor = UIColor.white
-    var borderColor = UIColor.black
-    var font = UIFont.systemFont(ofSize: 16)
-    var textAlignment = NSTextAlignment.center
-    var textColor = UIColor.black
-  }
+    struct Content: Equatable {
+        let frameOfTooltippedItem: CGRect?
+        let text: String
+        let customView: UIView
+    }
 
-  struct Content: Equatable {
-    let frameOfTooltippedItem: CGRect?
-    let text: String
-  }
+    static func makeView(
+        withInvariantViewProperties invariantViewProperties: InvariantViewProperties)
+        -> TooltipView
+    {
+        TooltipView(invariantViewProperties: invariantViewProperties)
+    }
 
-  static func makeView(
-    withInvariantViewProperties invariantViewProperties: InvariantViewProperties)
-    -> TooltipView
-  {
-    TooltipView(invariantViewProperties: invariantViewProperties)
-  }
-
-  static func setContent(_ content: Content, on view: TooltipView) {
-    view.frameOfTooltippedItem = content.frameOfTooltippedItem
-    view.text = content.text
-  }
-
+    static func setContent(_ content: Content, on view: TooltipView) {
+        view.frameOfTooltippedItem = content.frameOfTooltippedItem
+        view.text = content.text
+    }
 }


### PR DESCRIPTION
## Details

<!--- Describe your changes in detail —>

This merge consists of an error with tests where they were included in the wrong project file. XCTests was not recognized and caused build errors for the example project. After attempting multiple resolutions, a new test project was created.

The primary objective of this change is to insert spaces between rows and insert a space where users can type notes for a particular day. As of now, there is no saving of data, but this can easily be updated by the addition  of a handler [a future issue]. A tooltip-like view is added to the row above with the current date and a text box. Behavior is driven through the SwiftUI interface.

## Related Issue

<!--- If this is related to any issues, link them here. —>

This resolves issue #5 .

## Motivation and Context

<!--- Why is this change required? What problem does it solve? —>

This change enables users to add notes to a given day. It solves the issue of having to select a date, then handle any user input on another screen. Now, users can input text on the calendar screen. This can be expanded with more specific behavior when a user integrates it in their project.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. —>

This is a purely UI-driven project. No tests were written.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
