### PR TITLE
Scroll to Current day feature

### DIFF
--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/ScrollToDayWithAnimationDemoViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/ScrollToDayWithAnimationDemoViewController.swift
@@ -22,21 +22,30 @@ final class ScrollToDayWithAnimationDemoViewController: BaseDemoViewController {
     super.viewDidLoad()
 
     title = "Scroll to Day with Animation"
+    
+    // Add a Today button in the navigation bar
+    let todayButton = UIBarButtonItem(
+      title: "Today",
+      style: .plain,
+      target: self,
+      action: #selector(scrollToToday))
+    navigationItem.rightBarButtonItem = todayButton
   }
 
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
 
     let july2020 = calendar.date(from: DateComponents(year: 2020, month: 07, day: 11))!
-    calendarView.scroll(
-      toDayContaining: july2020,
-      scrollPosition: .centered,
-      animated: true)
+    calendarView.scrollToToday()
+  }
+  
+  @objc private func scrollToToday() {
+    calendarView.scrollToToday()
   }
 
   override func makeContent() -> CalendarViewContent {
     let startDate = calendar.date(from: DateComponents(year: 2016, month: 07, day: 01))!
-    let endDate = calendar.date(from: DateComponents(year: 2020, month: 12, day: 31))!
+    let endDate = calendar.date(from: DateComponents(year: 2027, month: 12, day: 31))!
 
     return CalendarViewContent(
       calendar: calendar,
@@ -44,5 +53,4 @@ final class ScrollToDayWithAnimationDemoViewController: BaseDemoViewController {
       monthsLayout: monthsLayout)
       .interMonthSpacing(24)
   }
-
 }

--- a/Sources/Public/CalendarView.swift
+++ b/Sources/Public/CalendarView.swift
@@ -184,6 +184,17 @@ public final class CalendarView: UIView {
 
     _layoutSubviews(extendLayoutRegion: extendLayoutRegion)
   }
+  /// Scrolls the calendar to show today's date.
+  ///
+  /// If the calendar has a non-zero frame, this function will scroll to today immediately. Otherwise the scroll-to-day
+  /// action will be queued and executed once the calendar has a non-zero frame.
+  ///
+  /// - Parameters:
+  ///   - scrollPosition: The final position at which today should be situated in the scroll view.
+  ///   - animated: Whether the scroll should be animated (from the current position).
+  public func scrollToToday(scrollPosition: CalendarViewScrollPosition = .centered, animated: Bool = true) {
+        scroll(toDayContaining: Date(), scrollPosition: scrollPosition, animated: animated)
+  }
 
   /// Sets the content of the `CalendarView`, causing it to re-render, with no animation.
   ///

--- a/Sources/Public/CalendarViewProxy.swift
+++ b/Sources/Public/CalendarViewProxy.swift
@@ -79,6 +79,17 @@ public final class CalendarViewProxy: ObservableObject {
       scrollPosition: scrollPosition,
       animated: animated)
   }
+  /// Scrolls the calendar to show today's date.
+  ///
+  /// If the calendar has a non-zero frame, this function will scroll to today immediately. Otherwise the scroll-to-day
+  /// action will be queued and executed once the calendar has a non-zero frame.
+  ///
+  /// - Parameters:
+  ///   - scrollPosition: The final position at which today should be situated in the scroll view.
+  ///   - animated: Whether the scroll should be animated (from the current position).
+  public func scrollToToday(scrollPosition: CalendarViewScrollPosition = .centered, animated: Bool = true) {
+        calendarView.scrollToToday(scrollPosition: scrollPosition, animated: animated)
+  }
 
   // MARK: Internal
 


### PR DESCRIPTION
## Details

Added a function to allow users to move the calendar back to the current date

## Related Issue

[Issue #13](https://github.com/WSU-CptS-581-2025/HorizonCalendar/issues/13)


## Motivation and Context

This change helps users keep their code cleaner. 

## How Has This Been Tested

- Ran existing tests
- Scrolling tests should cover functionality
- No effect on other areas

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
