### PR TITLE
Kp/30 complete call back handler for date selection

### DIFF
--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIFlexWeekViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIFlexWeekViewController.swift
@@ -148,11 +148,11 @@ struct SwiftUIFlexWeekDemo: View {
                         text: dayDateFormatter.string(from: selectedDate),
                         notes: UserDefaults.standard.string(forKey: "\(dayDateFormatter.string(from: selectedDate))notes") ?? "None",
                         scrollToSelectedDate: {
-//                            calendarViewProxy.scrollToDay(
-//                                containing: selectedDate,
-//                                scrollPosition: .lastFullyVisiblePosition(padding: 50),
-//                                animated: false
-//                            )
+                            calendarViewProxy.scrollToDay(
+                                containing: selectedDate,
+                                scrollPosition: .lastFullyVisiblePosition(padding: 200),
+                                animated: true
+                            )
                         },
                         didEndEditing: { newValue in
                             // Handle save operation of note here.

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIFlexWeekViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIFlexWeekViewController.swift
@@ -146,12 +146,19 @@ struct SwiftUIFlexWeekDemo: View {
                     content: SelectedDayView.Content(
                         frameOfTooltippedItem: frame,
                         text: dayDateFormatter.string(from: selectedDate),
-                        notes: "None", scrollToSelectedDate: {
-                            calendarViewProxy.scrollToDay(
-                                containing: selectedDate,
-                                scrollPosition: .lastFullyVisiblePosition(padding: 50),
-                                animated: false
-                            )
+                        notes: UserDefaults.standard.string(forKey: "\(dayDateFormatter.string(from: selectedDate))notes") ?? "None",
+                        scrollToSelectedDate: {
+//                            calendarViewProxy.scrollToDay(
+//                                containing: selectedDate,
+//                                scrollPosition: .lastFullyVisiblePosition(padding: 50),
+//                                animated: false
+//                            )
+                        },
+                        didEndEditing: { newValue in
+                            // Handle save operation of note here.
+                            UserDefaults.standard.set(newValue, forKey: "\(dayDateFormatter.string(from: selectedDate))notes")
+                            overlaidItemLocations = []
+                            selectedDayRange = nil
                         }
                     )
                 )

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIFlexWeekViewController.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/Demo View Controllers/SwiftUIFlexWeekViewController.swift
@@ -159,6 +159,7 @@ struct SwiftUIFlexWeekDemo: View {
                             UserDefaults.standard.set(newValue, forKey: "\(dayDateFormatter.string(from: selectedDate))notes")
                             overlaidItemLocations = []
                             selectedDayRange = nil
+                            lineSpacing = defaultLineSpacing
                         }
                     )
                 )
@@ -204,6 +205,8 @@ struct SwiftUIFlexWeekDemo: View {
 
     @State private var showErrorMessage: Bool = false
     @State private var lineSpacing: CGFloat = 28
+
+    private let defaultLineSpacing: CGFloat = 28
 
     private var selectedDateRanges: Set<ClosedRange<Date>> {
         guard let selectedDayRange else { return [] }

--- a/Example/HorizonCalendarExample/HorizonCalendarExample/SelectedDayView.swift
+++ b/Example/HorizonCalendarExample/HorizonCalendarExample/SelectedDayView.swift
@@ -111,6 +111,10 @@ final class SelectedDayView: UIView, UITextFieldDelegate {
         return true
     }
 
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        didEndEditing?(textField.text)
+    }
+
     // MARK: Fileprivate
 
     fileprivate var frameOfTooltippedItem: CGRect? {
@@ -136,6 +140,7 @@ final class SelectedDayView: UIView, UITextFieldDelegate {
     private let dateLabel: UILabel
     private let notes: UITextField
     private var scrollToSelectedDate: (() -> Void)?
+    private var didEndEditing: ((String?) -> Void)?
 }
 
 // MARK: CalendarItemViewRepresentable
@@ -160,6 +165,7 @@ extension SelectedDayView: CalendarItemViewRepresentable {
         let text: String
         let notes: String?
         let scrollToSelectedDate: (() -> Void)?
+        let didEndEditing: ((String?) -> Void)?
     }
 
     static func makeView(
@@ -174,5 +180,6 @@ extension SelectedDayView: CalendarItemViewRepresentable {
         view.dateText = content.text
         view.fieldTextContent = content.notes ?? ""
         view.scrollToSelectedDate = content.scrollToSelectedDate
+        view.didEndEditing = content.didEndEditing
     }
 }


### PR DESCRIPTION
## Details

Notes are now saved through an anonymous function. This allows for the method of reading and writing to change on the fly.

After the note is edited, the field is collapsed. User are able to select other dates now.

## Related Issue

*No related issues*

## Motivation and Context

This change is needed because once a date was selected, the text remained on the screen and other dates were non-selectable. Now data is saved which ensures notes persist between edits.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
