### PR TITLE
Kp/44 add customstringconvertible type to dayprotocol

### DIFF
--- a/Sources/Public/Day.swift
+++ b/Sources/Public/Day.swift
@@ -67,25 +67,26 @@ public struct Day: DayProtcol {
     }
 }
 
-// Implement Comparable
-public extension Day {
-    static func < (lhs: Day, rhs: Day) -> Bool {
+// MARK: Comparable
+
+extension Day: Comparable {
+    public static func < (lhs: Day, rhs: Day) -> Bool {
         lhs._dayComponents < rhs._dayComponents
     }
 
-    static func > (lhs: Day, rhs: Day) -> Bool {
+    public static func > (lhs: Day, rhs: Day) -> Bool {
         lhs._dayComponents > rhs._dayComponents
     }
 
-    static func == (lhs: Day, rhs: Day) -> Bool {
+    public static func == (lhs: Day, rhs: Day) -> Bool {
         lhs._dayComponents == rhs._dayComponents
     }
 
-    static func >= (lhs: Day, rhs: Day) -> Bool {
+    public static func >= (lhs: Day, rhs: Day) -> Bool {
         lhs == rhs || lhs > rhs
     }
 
-    static func <= (lhs: Day, rhs: Day) -> Bool {
+    public static func <= (lhs: Day, rhs: Day) -> Bool {
         lhs == rhs || lhs < rhs
     }
 }

--- a/Sources/Public/Day.swift
+++ b/Sources/Public/Day.swift
@@ -91,9 +91,10 @@ extension Day: Comparable {
     }
 }
 
-/// Explicitly implement Hashable
-public extension Day {
-    func hash(into hasher: inout Hasher) {
+// MARK: Hashable
+
+extension Day: Hashable {
+    public func hash(into hasher: inout Hasher) {
         hasher.combine(day)
         hasher.combine(month)
         hasher.combine(isEnabled)

--- a/Sources/Public/Day.swift
+++ b/Sources/Public/Day.swift
@@ -22,7 +22,7 @@ public protocol DayAvailabilityProvider {
     func isEnabled(_ day: Date) -> Bool
 }
 
-public protocol DayProtcol: Hashable, Comparable {
+public protocol DayProtcol: Hashable, Comparable, CustomStringConvertible {
     static var availabilityProvider: DayAvailabilityProvider? { get set }
 
     var components: DateComponents { get }

--- a/Sources/Public/DayComponents.swift
+++ b/Sources/Public/DayComponents.swift
@@ -37,9 +37,9 @@ public struct DayComponents: DayComponentsProtocol {
     public init(date: Date) {
         let comps = Calendar.current.dateComponents([.era, .year, .month, .day], from: date)
         month = MonthAlias(era: comps.era!,
-                      year: comps.year!,
-                      month: comps.month!,
-                      isInGregorianCalendar: Calendar.current.identifier == .gregorian)
+                           year: comps.year!,
+                           month: comps.month!,
+                           isInGregorianCalendar: Calendar.current.identifier == .gregorian)
         day = comps.day!
     }
 


### PR DESCRIPTION
## Details

Make DayProtocol inherit from CustomStringConvertible for consistency.

## Related Issue

Resolves issue #44 

## Motivation and Context

Ensures consistent readability.

## How Has This Been Tested

Ensure backwards compatibility.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
